### PR TITLE
Fix unproportionate image bug for profile and rivals across all the app

### DIFF
--- a/src/components/QuickInfo/styles.css
+++ b/src/components/QuickInfo/styles.css
@@ -7,9 +7,11 @@
 }
 
 .quickInfo__image {
-  max-width: 5.5rem;
+  width: 5.5rem;
+  height: 5.5rem;
   border: 2px solid white;
   border-radius: 50%;
+  object-fit: cover;
 }
 
 .quickInfo__nickname {

--- a/src/components/RivalQuickInfo/styles.css
+++ b/src/components/RivalQuickInfo/styles.css
@@ -11,9 +11,11 @@
 }
 
 .rivalQuickInfo__image {
-  max-width: 4.5rem;
+  width: 4.5rem;
+  height: 4.5rem;
   border: 2px solid white;
   border-radius: 50%;
+  object-fit: cover;
 }
 
 .rivalQuickInfo__nickname {

--- a/src/components/Topbar/styles.css
+++ b/src/components/Topbar/styles.css
@@ -18,8 +18,10 @@
 }
 
 .playerThumbnail__picture {
-  max-width: 4rem;
+  width: 4rem;
+  height: 4rem;
   border-radius: 50%;
+  object-fit: cover;
 }
 
 .topbar__vs-text {


### PR DESCRIPTION
Now, it looks as it should be:

![imagen](https://github.com/user-attachments/assets/6767060d-c2d4-452d-88af-d9f2065bc962)
