### PR TITLE
Implement delete fight logic

### DIFF
--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -34,32 +34,18 @@ function AppProvider({ children }: { children: ReactNode }) {
         image: "https://avatarfiles.alphacoders.com/362/thumb-1920-362804.jpg",
       },
     ],
-    history: [
+  });
+
+  const [historyEntries, setHistoryEntries] = useState<HistoryEntries>({
+    "13/10/2024": [
       {
-        date: currentDate,
-        rivalId: "a0c5d418-9894-4ecf-8b98-d5fcabc2aa25",
-        character2: "Scorpion",
-        character1: "Subzero",
-        win: true,
-      },
-      {
-        date: currentDate,
-        rivalId: "a0c5d418-9894-4ecf-8b98-d5fcabc2aa25",
-        character2: "Scorpion",
-        character1: "Subzero",
-        win: false,
-      },
-      {
-        date: currentDate,
+        date: "2024-10-13",
         rivalId: "a0c5d418-9894-4ecf-8b98-d5fcabc2aa25",
         character2: "Scorpion",
         character1: "Subzero",
         win: true,
       },
     ],
-  });
-
-  const [historyEntries, setHistoryEntries] = useState<HistoryEntries>({
     "14/10/2024": [
       {
         date: currentDate,
@@ -77,15 +63,6 @@ function AppProvider({ children }: { children: ReactNode }) {
       },
       {
         date: currentDate,
-        rivalId: "a0c5d418-9894-4ecf-8b98-d5fcabc2aa25",
-        character2: "Scorpion",
-        character1: "Subzero",
-        win: true,
-      },
-    ],
-    "13/10/2024": [
-      {
-        date: "2024-10-13",
         rivalId: "a0c5d418-9894-4ecf-8b98-d5fcabc2aa25",
         character2: "Scorpion",
         character1: "Subzero",

--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -6,7 +6,7 @@ import {
   HistoryEntry,
   HistoryEntries,
 } from "../types";
-import { currentDate, countVictoriesAndDefeats } from "../utils";
+import { currentDate } from "../utils";
 
 interface AppContextType {
   profileData: ProfileData;
@@ -19,6 +19,7 @@ interface AppContextType {
   historyEntries: HistoryEntries;
   setHistoryEntries: React.Dispatch<React.SetStateAction<HistoryEntries>>;
   setCurrentDayFights: React.Dispatch<React.SetStateAction<HistoryEntry[]>>;
+  countVictoriesAndDefeats(history: HistoryEntry[]): void;
 }
 
 const AppContext = createContext<AppContextType | undefined>(undefined);
@@ -39,7 +40,7 @@ function AppProvider({ children }: { children: ReactNode }) {
   const [historyEntries, setHistoryEntries] = useState<HistoryEntries>({
     "13/10/2024": [
       {
-        date: "2024-10-13",
+        date: "13/10/2024",
         rivalId: "a0c5d418-9894-4ecf-8b98-d5fcabc2aa25",
         character2: "Scorpion",
         character1: "Subzero",
@@ -48,21 +49,21 @@ function AppProvider({ children }: { children: ReactNode }) {
     ],
     "14/10/2024": [
       {
-        date: currentDate,
+        date: "14/10/2024",
         rivalId: "a0c5d418-9894-4ecf-8b98-d5fcabc2aa25",
         character2: "Scorpion",
         character1: "Subzero",
         win: true,
       },
       {
-        date: currentDate,
+        date: "14/10/2024",
         rivalId: "a0c5d418-9894-4ecf-8b98-d5fcabc2aa25",
         character2: "Scorpion",
         character1: "Subzero",
         win: false,
       },
       {
-        date: currentDate,
+        date: "14/10/2024",
         rivalId: "a0c5d418-9894-4ecf-8b98-d5fcabc2aa25",
         character2: "Scorpion",
         character1: "Subzero",
@@ -79,6 +80,28 @@ function AppProvider({ children }: { children: ReactNode }) {
   const [victoryCounter, setVictoryCounter] = useState<number>(0);
   const [defeatCounter, setDefeatCounter] = useState<number>(0);
 
+  function countVictoriesAndDefeats(history: HistoryEntry[] | undefined) {
+    let victories: number = 0;
+    let defeats: number = 0;
+    if (!history) {
+      // Because in this case there aren't any fights to count
+      // So I reset the counters to default values
+      setVictoryCounter(victories);
+      setDefeatCounter(defeats);
+      return;
+    }
+
+    history.forEach((fight) => {
+      if (fight.win) {
+        victories++;
+      } else {
+        defeats++;
+      }
+    });
+    setVictoryCounter(victories);
+    setDefeatCounter(defeats);
+  }
+
   useEffect(() => {
     if (!historyEntries[currentDate]) {
       // Because in this case there are no existing fights for the currentDate
@@ -86,11 +109,7 @@ function AppProvider({ children }: { children: ReactNode }) {
     }
     if (historyEntries[currentDate].length > 0) {
       setCurrentDayFights(historyEntries[currentDate]);
-      const { victories, defeats } = countVictoriesAndDefeats(
-        historyEntries[currentDate],
-      );
-      setDefeatCounter(defeats);
-      setVictoryCounter(victories);
+      countVictoriesAndDefeats(historyEntries[currentDate]);
     }
   }, [historyEntries]);
 
@@ -107,6 +126,7 @@ function AppProvider({ children }: { children: ReactNode }) {
         historyEntries,
         setHistoryEntries,
         setCurrentDayFights,
+        countVictoriesAndDefeats,
       }}
     >
       {children}

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -22,12 +22,7 @@ export function HistoryPage() {
 
   function handleFightDelete(fight: HistoryEntry, fightIndex: number) {
     const updatedEntries = { ...historyEntries };
-    let dayFights = updatedEntries[fight.date];
-
-    dayFights = dayFights.filter(
-      (entry) => dayFights.indexOf(entry) !== fightIndex,
-    );
-    updatedEntries[fight.date] = dayFights;
+    updatedEntries[fight.date].splice(fightIndex, 1);
 
     if (updatedEntries[fight.date].length === 0) {
       delete updatedEntries[fight.date];

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -98,8 +98,29 @@ function FightResume({
           <img className="fightItem__playerImage" src={profileData.image} />
           <p className="fightItem__character1Text">{fight.character1}</p>
         </div>
-        <p className="fightItem__result">{fight.win ? "WIN" : "LOSE"}</p>
-        <button onClick={() => deleteFight(fight, index)}>Delete</button>
+        <div className="resultContainer">
+          <p className="resultContainer__result">
+            {fight.win ? "WIN" : "LOSE"}
+          </p>
+          <button
+            className="deleteFight"
+            onClick={() => deleteFight(fight, index)}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth="1.5"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="m9.75 9.75 4.5 4.5m0-4.5-4.5 4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+              />
+            </svg>
+          </button>
+        </div>
         <div className="fightItem__thumbnail">
           <p className="fightItem__rivalNickname">{rivalData?.nickname}</p>
           <img className="fightItem__rivalImage" src={rivalData?.image} />

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -14,35 +14,37 @@ export function HistoryPage() {
   return (
     <section className="container">
       <h2 className="container__title">History</h2>
-      {Object.keys(historyEntries).map((date) => {
-        return (
-          <article className="history" key={date}>
-            <h3 className="history__date">{date}</h3>
-            <ul className="fightList">
-              {historyEntries[date].map((entry, index) => {
-                // Busca la información del rival usando su ID
-                const rivalData = profileData.rivals.find(
-                  (rival) => rival.id === entry.rivalId,
-                );
-
-                if (!rivalData) {
-                  throw new Error(
-                    "rivalData is undefined, so the entry.rivalId is pointing to a non existing rival",
+      {Object.keys(historyEntries)
+        .reverse()
+        .map((date) => {
+          return (
+            <article className="history" key={date}>
+              <h3 className="history__date">{date}</h3>
+              <ul className="fightList">
+                {historyEntries[date].map((entry, index) => {
+                  // Busca la información del rival usando su ID
+                  const rivalData = profileData.rivals.find(
+                    (rival) => rival.id === entry.rivalId,
                   );
-                }
-                return (
-                  <FightResume
-                    key={index}
-                    profileData={profileData}
-                    fight={entry}
-                    rivalData={rivalData}
-                  />
-                );
-              })}
-            </ul>
-          </article>
-        );
-      })}
+
+                  if (!rivalData) {
+                    throw new Error(
+                      "rivalData is undefined, so the entry.rivalId is pointing to a non existing rival",
+                    );
+                  }
+                  return (
+                    <FightResume
+                      key={index}
+                      profileData={profileData}
+                      fight={entry}
+                      rivalData={rivalData}
+                    />
+                  );
+                })}
+              </ul>
+            </article>
+          );
+        })}
     </section>
   );
 }

--- a/src/pages/history/styles.css
+++ b/src/pages/history/styles.css
@@ -32,6 +32,7 @@
   justify-content: center;
   align-items: center;
   justify-content: space-between;
+  position: relative;
 }
 
 .fightItem__thumbnail {
@@ -39,14 +40,19 @@
   place-items: center;
 }
 
+.resultContainer {
+  display: grid;
+  place-items: center;
+}
+
 .fightItem__playerNickname,
 .fightItem__rivalNickname,
-.fightItem__result {
+.resultContainer__result {
   font-size: 1rem;
   font-weight: bold;
 }
 
-.fightItem__result {
+.resultContainer__result {
   font-weight: bolder;
 }
 
@@ -56,4 +62,12 @@
   height: 6rem;
   border: 2px solid white;
   border-radius: 50%;
+}
+
+.deleteFight {
+  background-color: inherit;
+  border: none;
+  width: 3rem;
+  height: 3rem;
+  color: white;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,6 @@ export interface ProfileData {
   nickname: string;
   image: string;
   rivals: Rival[];
-  history: HistoryEntry[];
 }
 
 export type HistoryEntries = Record<string, HistoryEntry[]>;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,19 +1,4 @@
-import { HistoryEntry } from "../types";
-
-function countVictoriesAndDefeats(history: HistoryEntry[]) {
-  let victories: number = 0;
-  let defeats: number = 0;
-  history.forEach((fight) => {
-    if (fight.win) {
-      victories++;
-    } else {
-      defeats++;
-    }
-  });
-  return { victories, defeats };
-}
-
 const now = new Date();
 const currentDate = now.toLocaleDateString();
 
-export { currentDate, countVictoriesAndDefeats };
+export { currentDate };


### PR DESCRIPTION
With this PR I did:

1. Add a new state, `historyEntries` that is an object, that classifies by date the fights, and inside each date key, there is a `HistoryEntry[]`
2. Update the /history page to add a new button for each fight, is an X one, to delete the fight
3. Lastly, I removed unused states and data when possible that were related with the history logic.