### PR TITLE
Implement delete rival logic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,17 +22,23 @@ function App() {
     currentDayFights,
   } = context;
   const [openModal, setOpenModal] = useState<boolean>(false);
+  const [isRivalData, setIsRivalData] = useState<boolean>(
+    profileData.rivals.length > 0,
+  );
+
   return (
     <>
       {/* <header>MK-Dashboard</header> */}
-      <TopBar
-        playerName={profileData.nickname}
-        playerImage={profileData.image}
-        rivalName={profileData.rivals[0].nickname}
-        rivalImage={profileData.rivals[0].image}
-        victoryCounter={victoryCounter}
-        defeatCounter={defeatCounter}
-      />
+      {isRivalData && (
+        <TopBar
+          playerName={profileData.nickname}
+          playerImage={profileData.image}
+          rivalName={profileData.rivals[0].nickname}
+          rivalImage={profileData.rivals[0].image}
+          victoryCounter={victoryCounter}
+          defeatCounter={defeatCounter}
+        />
+      )}
       <main>
         {currentDayFights
           ?.map((fight: HistoryEntry, index) => {

--- a/src/components/RivalQuickInfo/index.tsx
+++ b/src/components/RivalQuickInfo/index.tsx
@@ -1,13 +1,15 @@
 import { Link } from "react-router-dom";
 import "./styles.css";
+import { Rival } from "../../types";
 
 interface Props {
   name: string;
   image: string;
   rivalId: string;
+  deleteRival(rivalId: Rival["id"]): void;
 }
 
-export function RivalQuickInfo({ name, image, rivalId }: Props) {
+export function RivalQuickInfo({ name, image, rivalId, deleteRival }: Props) {
   return (
     <article className="rivalQuickInfo">
       <img className="rivalQuickInfo__image" src={image} />
@@ -27,20 +29,22 @@ export function RivalQuickInfo({ name, image, rivalId }: Props) {
           />
         </svg>
       </Link>
-      <svg
-        className="rivalQuickInfo__delete"
-        xmlns="http://www.w3.org/2000/svg"
-        fill="none"
-        viewBox="0 0 24 24"
-        strokeWidth="1.5"
-        stroke="currentColor"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="m9.75 9.75 4.5 4.5m0-4.5-4.5 4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
-        />
-      </svg>
+      <button onClick={() => deleteRival(rivalId)}>
+        <svg
+          className="rivalQuickInfo__delete"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth="1.5"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="m9.75 9.75 4.5 4.5m0-4.5-4.5 4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+          />
+        </svg>
+      </button>
     </article>
   );
 }

--- a/src/components/RivalQuickInfo/index.tsx
+++ b/src/components/RivalQuickInfo/index.tsx
@@ -29,9 +29,11 @@ export function RivalQuickInfo({ name, image, rivalId, deleteRival }: Props) {
           />
         </svg>
       </Link>
-      <button onClick={() => deleteRival(rivalId)}>
+      <button
+        className="rivalQuickInfo__delete"
+        onClick={() => deleteRival(rivalId)}
+      >
         <svg
-          className="rivalQuickInfo__delete"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/src/components/RivalQuickInfo/styles.css
+++ b/src/components/RivalQuickInfo/styles.css
@@ -39,7 +39,12 @@
   position: absolute;
   background-color: inherit;
   border-radius: 50%;
+  padding: 0;
+  border: none;
+  color: white;
   top: -1rem;
   right: -1rem;
   width: 3rem;
+  height: 3rem;
+  cursor: pointer;
 }

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -7,20 +7,27 @@ import { RivalForm } from "../../components/RivalForm";
 import { RivalQuickInfo } from "../../components/RivalQuickInfo";
 import "./styles.css";
 import { Rival } from "../../types";
+import { currentDate } from "../../utils";
 
 export function ProfilePage() {
   const context = useContext(AppContext);
   if (!context) {
     throw new Error("AppContext should be used inside an AppProvider");
   }
-  const { profileData, historyEntries, setProfileData, setHistoryEntries } =
-    context;
+  const {
+    profileData,
+    historyEntries,
+    setProfileData,
+    setHistoryEntries,
+    setCurrentDayFights,
+  } = context;
 
   const [openModal, setOpenModal] = useState<boolean>(false);
 
   function handleRivalDelete(rivalId: Rival["id"]) {
-    console.warn(historyEntries);
     const updatedHistoryEntries = { ...historyEntries };
+
+    // TODO: Refactor this to a context function or a easier to read one
 
     for (const date in updatedHistoryEntries) {
       if (Object.prototype.hasOwnProperty.call(updatedHistoryEntries, date)) {
@@ -34,6 +41,12 @@ export function ProfilePage() {
           updatedHistoryEntries[date] = filteredFights;
         }
       }
+
+      if (date !== currentDate) {
+        continue;
+      }
+
+      setCurrentDayFights(updatedHistoryEntries[date]);
     }
 
     setHistoryEntries(updatedHistoryEntries);

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -19,40 +19,35 @@ export function ProfilePage() {
   const [openModal, setOpenModal] = useState<boolean>(false);
 
   function handleRivalDelete(rivalId: Rival["id"]) {
+    console.warn(historyEntries);
     const updatedHistoryEntries = { ...historyEntries };
 
-    for (
-      let index = 0;
-      index < Object.values(updatedHistoryEntries).length;
-      index++
-    ) {
-      let dayFightsArray = Object.values(updatedHistoryEntries)[index];
-      let date = "";
-      const filteredFights = dayFightsArray.filter((entry) => {
-        date = entry.date;
-        return entry.rivalId !== rivalId;
-      });
-      
-      console.warn(filteredFights)
+    for (const date in updatedHistoryEntries) {
+      if (Object.prototype.hasOwnProperty.call(updatedHistoryEntries, date)) {
+        const filteredFights = updatedHistoryEntries[date].filter((entry) => {
+          return entry.rivalId !== rivalId;
+        });
 
-      dayFightsArray = filteredFights;
-
-      if (dayFightsArray.length === 0) {
-        delete updatedHistoryEntries[date];
+        if (filteredFights.length === 0) {
+          delete updatedHistoryEntries[date];
+        } else {
+          updatedHistoryEntries[date] = filteredFights;
+        }
       }
     }
 
     setHistoryEntries(updatedHistoryEntries);
 
-    // const updatedProfileData = { ...profileData };
-    // const rivals = updatedProfileData.rivals;
-    // const rivalIndex = rivals.findIndex((rival) => rival.id === rivalId);
+    const rivals = Array.from(profileData.rivals);
+    const rivalIndex = rivals.findIndex((rival) => rival.id === rivalId);
+    rivals.splice(rivalIndex, 1);
 
-    // rivals.splice(rivalIndex, 1);
-
-    // setProfileData(updatedProfileData);
+    setProfileData({
+      ...profileData,
+      rivals,
+    });
   }
-  
+
   return (
     <>
       <QuickInfo />

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -6,15 +6,53 @@ import { Modal } from "../../components/Modal";
 import { RivalForm } from "../../components/RivalForm";
 import { RivalQuickInfo } from "../../components/RivalQuickInfo";
 import "./styles.css";
+import { Rival } from "../../types";
 
 export function ProfilePage() {
   const context = useContext(AppContext);
   if (!context) {
     throw new Error("AppContext should be used inside an AppProvider");
   }
-  const { profileData } = context;
+  const { profileData, historyEntries, setProfileData, setHistoryEntries } =
+    context;
 
   const [openModal, setOpenModal] = useState<boolean>(false);
+
+  function handleRivalDelete(rivalId: Rival["id"]) {
+    const updatedHistoryEntries = { ...historyEntries };
+
+    for (
+      let index = 0;
+      index < Object.values(updatedHistoryEntries).length;
+      index++
+    ) {
+      let dayFightsArray = Object.values(updatedHistoryEntries)[index];
+      let date = "";
+      const filteredFights = dayFightsArray.filter((entry) => {
+        date = entry.date;
+        return entry.rivalId !== rivalId;
+      });
+      
+      console.warn(filteredFights)
+
+      dayFightsArray = filteredFights;
+
+      if (dayFightsArray.length === 0) {
+        delete updatedHistoryEntries[date];
+      }
+    }
+
+    setHistoryEntries(updatedHistoryEntries);
+
+    // const updatedProfileData = { ...profileData };
+    // const rivals = updatedProfileData.rivals;
+    // const rivalIndex = rivals.findIndex((rival) => rival.id === rivalId);
+
+    // rivals.splice(rivalIndex, 1);
+
+    // setProfileData(updatedProfileData);
+  }
+  
   return (
     <>
       <QuickInfo />
@@ -32,6 +70,7 @@ export function ProfilePage() {
               rivalId={rival.id}
               name={rival.nickname}
               image={rival.image}
+              deleteRival={handleRivalDelete}
             />
           );
         })}


### PR DESCRIPTION
This took me a bit more time than I expected, but here is what I changed:

1. Added a new function `handleRivalDelete` that looks in each fight entry within `historyEntries` and filters the fights where the `rivalId` is not the same as the one found in the single fight entry.
2. After that, it removes the rival data from the rivals array using a `.splice()`.
3. Added basic styles to the `deleteRival` button
4. Lastly, added a new state, `isRivalData`, to only render `TopBar` in `App.tsx` if there rivals in `profileData.rivals`