### PR TITLE
Add select current rival

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,6 +74,17 @@ function App() {
 
       return (
         <>
+          {rivalData && (
+            <TopBar
+              playerName={profileData.nickname}
+              playerImage={profileData.image}
+              rivalName={rivalData.nickname}
+              rivalImage={rivalData.image}
+              victoryCounter={victoryCounter}
+              defeatCounter={defeatCounter}
+            />
+          )}
+
           <label className="form__label" htmlFor="rivalSelect">
             Choose your rival
           </label>
@@ -93,17 +104,6 @@ function App() {
               );
             })}
           </select>
-
-          {rivalData && (
-            <TopBar
-              playerName={profileData.nickname}
-              playerImage={profileData.image}
-              rivalName={rivalData.nickname}
-              rivalImage={rivalData.image}
-              victoryCounter={victoryCounter}
-              defeatCounter={defeatCounter}
-            />
-          )}
         </>
       );
     } else {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { NewFightForm } from "./components/NewFightForm";
 import { AppContext } from "./context";
 import { NoRivalsGuide } from "./components/NoRivalsGuide";
 import { currentDate } from "./utils";
+import { SelectCurrentRival } from "./components/SelectCurrentRival";
 
 function App() {
   const context = useContext(AppContext);
@@ -85,25 +86,10 @@ function App() {
             />
           )}
 
-          <label className="form__label" htmlFor="rivalSelect">
-            Choose your rival
-          </label>
-
-          <select
-            className="form__select"
-            id="rivalSelect"
-            name="rivalOptions"
-            onChange={(event) => setCurrentRivalId(event.target.value)}
-          >
-            <option value="">-- Choose a rival --</option>
-            {profileData.rivals.map((rival) => {
-              return (
-                <option key={rival.id} value={rival.id}>
-                  {rival.nickname}
-                </option>
-              );
-            })}
-          </select>
+          <SelectCurrentRival
+            rivals={profileData.rivals}
+            setCurrentRivalId={setCurrentRivalId}
+          />
         </>
       );
     } else {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useRef, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { AddFightButton } from "./components/AddFight";
 import { FightResult } from "./components/FightResult";
 import { TopBar } from "./components/Topbar";
@@ -22,13 +22,11 @@ function App() {
   const [currentRivalFights, setCurrentRivalFights] = useState<HistoryEntry[]>(
     [],
   );
-  const [currentRivalId, setCurrentRivalId] = useState<Rival["id"]>("");
-
-  const rivalRef = useRef<HTMLSelectElement>(null);
-  let isRivalData: boolean = false;
-
   const [victoryCounter, setVictoryCounter] = useState<number>(0);
   const [defeatCounter, setDefeatCounter] = useState<number>(0);
+  const [currentRivalId, setCurrentRivalId] = useState<Rival["id"]>("");
+
+  let isRivalData: boolean = false;
 
   function countVictoriesAndDefeats(history: HistoryEntry[] | undefined) {
     let victories: number = 0;
@@ -57,7 +55,6 @@ function App() {
       // Because in this case there are no existing fights for the currentDate
       return;
     }
-
     if (historyEntries[currentDate].length > 0) {
       const filteredFights = historyEntries[currentDate].filter(
         (fight) => fight.rivalId === currentRivalId,
@@ -70,16 +67,21 @@ function App() {
   function renderHeader() {
     if (profileData && profileData.rivals.length > 0) {
       isRivalData = true;
+
+      const rivalData = profileData.rivals.find(
+        (rival) => rival.id === currentRivalId,
+      );
+
       return (
         <>
           <label className="form__label" htmlFor="rivalSelect">
             Choose your rival
           </label>
+
           <select
             className="form__select"
             id="rivalSelect"
             name="rivalOptions"
-            ref={rivalRef}
             onChange={(event) => setCurrentRivalId(event.target.value)}
           >
             <option value="">-- Choose a rival --</option>
@@ -91,14 +93,17 @@ function App() {
               );
             })}
           </select>
-          <TopBar
-            playerName={profileData.nickname}
-            playerImage={profileData.image}
-            rivalName={profileData.rivals[0].nickname}
-            rivalImage={profileData.rivals[0].image}
-            victoryCounter={victoryCounter}
-            defeatCounter={defeatCounter}
-          />
+
+          {rivalData && (
+            <TopBar
+              playerName={profileData.nickname}
+              playerImage={profileData.image}
+              rivalName={rivalData.nickname}
+              rivalImage={rivalData.image}
+              victoryCounter={victoryCounter}
+              defeatCounter={defeatCounter}
+            />
+          )}
         </>
       );
     } else {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,14 @@
-import { useContext, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import { AddFightButton } from "./components/AddFight";
 import { FightResult } from "./components/FightResult";
 import { TopBar } from "./components/Topbar";
 import "./styles.css";
-import { HistoryEntry } from "./types";
+import { HistoryEntry, Rival } from "./types";
 import { Modal } from "./components/Modal";
 import { NewFightForm } from "./components/NewFightForm";
 import { AppContext } from "./context";
 import { NoRivalsGuide } from "./components/NoRivalsGuide";
+import { currentDate } from "./utils";
 
 function App() {
   const context = useContext(AppContext);
@@ -15,28 +16,90 @@ function App() {
     throw new Error("AppContext should be used inside an AppProvider");
   }
 
-  const {
-    profileData,
-    charactersData,
-    victoryCounter,
-    defeatCounter,
-    currentDayFights,
-  } = context;
+  const { profileData, charactersData, historyEntries } = context;
+
   const [openModal, setOpenModal] = useState<boolean>(false);
+  const [currentRivalFights, setCurrentRivalFights] = useState<HistoryEntry[]>(
+    [],
+  );
+  const [currentRivalId, setCurrentRivalId] = useState<Rival["id"]>("");
+
+  const rivalRef = useRef<HTMLSelectElement>(null);
   let isRivalData: boolean = false;
+
+  const [victoryCounter, setVictoryCounter] = useState<number>(0);
+  const [defeatCounter, setDefeatCounter] = useState<number>(0);
+
+  function countVictoriesAndDefeats(history: HistoryEntry[] | undefined) {
+    let victories: number = 0;
+    let defeats: number = 0;
+    if (!history) {
+      // Because in this case there aren't any fights to count
+      // So I reset the counters to default values
+      setVictoryCounter(victories);
+      setDefeatCounter(defeats);
+      return;
+    }
+
+    history.forEach((fight) => {
+      if (fight.win) {
+        victories++;
+      } else {
+        defeats++;
+      }
+    });
+    setVictoryCounter(victories);
+    setDefeatCounter(defeats);
+  }
+
+  useEffect(() => {
+    if (!historyEntries[currentDate]) {
+      // Because in this case there are no existing fights for the currentDate
+      return;
+    }
+
+    if (historyEntries[currentDate].length > 0) {
+      const filteredFights = historyEntries[currentDate].filter(
+        (fight) => fight.rivalId === currentRivalId,
+      );
+      setCurrentRivalFights(filteredFights);
+      countVictoriesAndDefeats(filteredFights);
+    }
+  }, [historyEntries, currentRivalId]);
 
   function renderHeader() {
     if (profileData && profileData.rivals.length > 0) {
       isRivalData = true;
       return (
-        <TopBar
-          playerName={profileData.nickname}
-          playerImage={profileData.image}
-          rivalName={profileData.rivals[0].nickname}
-          rivalImage={profileData.rivals[0].image}
-          victoryCounter={victoryCounter}
-          defeatCounter={defeatCounter}
-        />
+        <>
+          <label className="form__label" htmlFor="rivalSelect">
+            Choose your rival
+          </label>
+          <select
+            className="form__select"
+            id="rivalSelect"
+            name="rivalOptions"
+            ref={rivalRef}
+            onChange={(event) => setCurrentRivalId(event.target.value)}
+          >
+            <option value="">-- Choose a rival --</option>
+            {profileData.rivals.map((rival) => {
+              return (
+                <option key={rival.id} value={rival.id}>
+                  {rival.nickname}
+                </option>
+              );
+            })}
+          </select>
+          <TopBar
+            playerName={profileData.nickname}
+            playerImage={profileData.image}
+            rivalName={profileData.rivals[0].nickname}
+            rivalImage={profileData.rivals[0].image}
+            victoryCounter={victoryCounter}
+            defeatCounter={defeatCounter}
+          />
+        </>
       );
     } else {
       return <NoRivalsGuide />;
@@ -47,7 +110,7 @@ function App() {
     <>
       {renderHeader()}
       <section className="currentDayFights">
-        {currentDayFights
+        {currentRivalFights
           ?.map((fight: HistoryEntry, index) => {
             const character1Data = charactersData.find(
               (character) => character.name === fight.character1,

--- a/src/components/NewFightForm/index.tsx
+++ b/src/components/NewFightForm/index.tsx
@@ -14,13 +14,8 @@ export function NewFightForm({ setOpenModal }: Props) {
     throw new Error("AppContext should be used inside an AppProvider");
   }
 
-  const {
-    profileData,
-    charactersData,
-    historyEntries,
-    setHistoryEntries,
-    // setCurrentDayFights,
-  } = context;
+  const { profileData, charactersData, historyEntries, setHistoryEntries } =
+    context;
 
   const rivalRef = useRef<HTMLSelectElement>(null);
   const character1Ref = useRef<HTMLSelectElement>(null);
@@ -75,7 +70,6 @@ because you should only render NewFightForm when there is profileData`);
       updatedHistory[currentDate].push(newFight);
     }
     setHistoryEntries(updatedHistory);
-    // setCurrentDayFights(updatedHistory[currentDate]);
 
     setOpenModal(false);
   }

--- a/src/components/NewFightForm/index.tsx
+++ b/src/components/NewFightForm/index.tsx
@@ -19,7 +19,7 @@ export function NewFightForm({ setOpenModal }: Props) {
     charactersData,
     historyEntries,
     setHistoryEntries,
-    setCurrentDayFights,
+    // setCurrentDayFights,
   } = context;
 
   const rivalRef = useRef<HTMLSelectElement>(null);
@@ -75,7 +75,7 @@ because you should only render NewFightForm when there is profileData`);
       updatedHistory[currentDate].push(newFight);
     }
     setHistoryEntries(updatedHistory);
-    setCurrentDayFights(updatedHistory[currentDate]);
+    // setCurrentDayFights(updatedHistory[currentDate]);
 
     setOpenModal(false);
   }

--- a/src/components/SelectCurrentRival/index.tsx
+++ b/src/components/SelectCurrentRival/index.tsx
@@ -1,0 +1,33 @@
+import { Rival } from "../../types";
+import "./styles.css";
+
+interface Props {
+  rivals: Rival[];
+  setCurrentRivalId: React.Dispatch<React.SetStateAction<Rival["id"]>>;
+}
+
+export function SelectCurrentRival({ rivals, setCurrentRivalId }: Props) {
+  return (
+    <div className="currentRival">
+      <label className="currentRival__label" htmlFor="rivalSelect">
+        Choose your rival
+      </label>
+
+      <select
+        className="currentRival__select"
+        id="rivalSelect"
+        name="rivalOptions"
+        onChange={(event) => setCurrentRivalId(event.target.value)}
+      >
+        <option value="">-- Choose a rival --</option>
+        {rivals.map((rival) => {
+          return (
+            <option key={rival.id} value={rival.id}>
+              {rival.nickname}
+            </option>
+          );
+        })}
+      </select>
+    </div>
+  );
+}

--- a/src/components/SelectCurrentRival/styles.css
+++ b/src/components/SelectCurrentRival/styles.css
@@ -1,0 +1,20 @@
+.currentRival {
+  display: flex;
+  justify-content: space-between;
+  padding: 1rem;
+}
+
+.currentRival__label {
+  font-weight: bold;
+}
+
+.currentRival__select {
+  background-color: #2f2f2f;
+  width: 45%;
+  text-align: center;
+  color: white;
+  font-size: 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid whitesmoke;
+  font-weight: bolder;
+}

--- a/src/components/Topbar/index.tsx
+++ b/src/components/Topbar/index.tsx
@@ -18,7 +18,7 @@ export function TopBar({
   defeatCounter,
 }: Props) {
   return (
-    <nav className="topbar">
+    <div className="topbar">
       <div className="playerThumbnail">
         <p className="playerThumbnail__nickname">{playerName}</p>
         <img className="playerThumbnail__picture" src={playerImage} />
@@ -30,6 +30,6 @@ export function TopBar({
         <p className="playerThumbnail__nickname">{rivalName}</p>
         <img className="playerThumbnail__picture" src={rivalImage} />
       </div>
-    </nav>
+    </div>
   );
 }

--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -1,31 +1,20 @@
 import { createContext } from "react";
-import { ReactNode, useEffect, useState } from "react";
-import {
-  ProfileData,
-  CharacterData,
-  HistoryEntry,
-  HistoryEntries,
-} from "../types";
-import { currentDate } from "../utils";
+import { ReactNode, useState } from "react";
+import { ProfileData, CharacterData, HistoryEntries } from "../types";
 
 interface AppContextType {
   profileData: ProfileData | null;
   setProfileData: React.Dispatch<React.SetStateAction<ProfileData | null>>;
   charactersData: CharacterData[];
   setCharactersData: React.Dispatch<React.SetStateAction<CharacterData[]>>;
-  victoryCounter: number;
-  defeatCounter: number;
-  currentDayFights: HistoryEntry[];
   historyEntries: HistoryEntries;
   setHistoryEntries: React.Dispatch<React.SetStateAction<HistoryEntries>>;
-  setCurrentDayFights: React.Dispatch<React.SetStateAction<HistoryEntry[]>>;
-  countVictoriesAndDefeats(history: HistoryEntry[]): void;
 }
 
 const AppContext = createContext<AppContextType | undefined>(undefined);
 
 function AppProvider({ children }: { children: ReactNode }) {
-  // const [profileData, setProfileData] = useState<ProfileData>({
+  // const [profileData, setProfileData] = useState<ProfileData | null>({
   //   nickname: "Lenoxo",
   //   image: "https://avatarfiles.alphacoders.com/359/thumb-1920-359966.jpg",
   //   rivals: [
@@ -34,9 +23,14 @@ function AppProvider({ children }: { children: ReactNode }) {
   //       nickname: "Rival 1",
   //       image: "https://avatarfiles.alphacoders.com/362/thumb-1920-362804.jpg",
   //     },
+  //     {
+  //       id: "b1c5d418-9894-4ecf-8b98-d5fcabc2aa25",
+  //       nickname: "Rival 2",
+  //       image: "https://avatarfiles.alphacoders.com/362/thumb-1920-362804.jpg",
+  //     },
   //   ],
   // });
-
+  //
   const [profileData, setProfileData] = useState<ProfileData | null>(null);
   const [historyEntries, setHistoryEntries] = useState<HistoryEntries>({});
   // const [historyEntries, setHistoryEntries] = useState<HistoryEntries>({
@@ -78,43 +72,6 @@ function AppProvider({ children }: { children: ReactNode }) {
     { name: "Subzero", imageUrl: "https://imgur.com/i6pgo8i.png" },
   ]);
 
-  const [currentDayFights, setCurrentDayFights] = useState<HistoryEntry[]>([]);
-  const [victoryCounter, setVictoryCounter] = useState<number>(0);
-  const [defeatCounter, setDefeatCounter] = useState<number>(0);
-
-  function countVictoriesAndDefeats(history: HistoryEntry[] | undefined) {
-    let victories: number = 0;
-    let defeats: number = 0;
-    if (!history) {
-      // Because in this case there aren't any fights to count
-      // So I reset the counters to default values
-      setVictoryCounter(victories);
-      setDefeatCounter(defeats);
-      return;
-    }
-
-    history.forEach((fight) => {
-      if (fight.win) {
-        victories++;
-      } else {
-        defeats++;
-      }
-    });
-    setVictoryCounter(victories);
-    setDefeatCounter(defeats);
-  }
-
-  useEffect(() => {
-    if (!historyEntries[currentDate]) {
-      // Because in this case there are no existing fights for the currentDate
-      return;
-    }
-    if (historyEntries[currentDate].length > 0) {
-      setCurrentDayFights(historyEntries[currentDate]);
-      countVictoriesAndDefeats(historyEntries[currentDate]);
-    }
-  }, [historyEntries]);
-
   return (
     <AppContext.Provider
       value={{
@@ -122,13 +79,13 @@ function AppProvider({ children }: { children: ReactNode }) {
         setProfileData,
         charactersData,
         setCharactersData,
-        victoryCounter,
-        defeatCounter,
-        currentDayFights,
+        // victoryCounter,
+        // defeatCounter,
+        // currentDayFights,
         historyEntries,
         setHistoryEntries,
-        setCurrentDayFights,
-        countVictoriesAndDefeats,
+        // setCurrentDayFights,
+        // countVictoriesAndDefeats,
       }}
     >
       {children}

--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -79,13 +79,8 @@ function AppProvider({ children }: { children: ReactNode }) {
         setProfileData,
         charactersData,
         setCharactersData,
-        // victoryCounter,
-        // defeatCounter,
-        // currentDayFights,
         historyEntries,
         setHistoryEntries,
-        // setCurrentDayFights,
-        // countVictoriesAndDefeats,
       }}
     >
       {children}

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -2,7 +2,6 @@ import { useContext } from "react";
 import { AppContext } from "../../context";
 import { HistoryEntry, ProfileData, Rival } from "../../types";
 import "./styles.css";
-import { currentDate } from "../../utils";
 
 export function HistoryPage() {
   const context = useContext(AppContext);
@@ -10,15 +9,7 @@ export function HistoryPage() {
     throw new Error("AppContext should be used inside an AppProvider");
   }
 
-  const {
-    setCurrentDayFights,
-    profileData,
-    historyEntries,
-    setHistoryEntries,
-    countVictoriesAndDefeats,
-  } = context;
-
-  // TODO: Optimize the history render and delete if possible
+  const { profileData, historyEntries, setHistoryEntries } = context;
 
   function handleFightDelete(fight: HistoryEntry, fightIndex: number) {
     const updatedEntries = { ...historyEntries };
@@ -29,11 +20,6 @@ export function HistoryPage() {
     }
 
     setHistoryEntries(updatedEntries);
-
-    if (fight.date === currentDate) {
-      setCurrentDayFights(updatedEntries[currentDate]);
-      countVictoriesAndDefeats(updatedEntries[currentDate]);
-    }
   }
   return (
     <section className="container">

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -7,7 +7,6 @@ import { RivalForm } from "../../components/RivalForm";
 import { RivalQuickInfo } from "../../components/RivalQuickInfo";
 import "./styles.css";
 import { Rival } from "../../types";
-import { currentDate } from "../../utils";
 import { NewUserGuide } from "../../components/NewUserGuide";
 
 export function ProfilePage() {
@@ -15,13 +14,8 @@ export function ProfilePage() {
   if (!context) {
     throw new Error("AppContext should be used inside an AppProvider");
   }
-  const {
-    profileData,
-    historyEntries,
-    setProfileData,
-    setHistoryEntries,
-    setCurrentDayFights,
-  } = context;
+  const { profileData, historyEntries, setProfileData, setHistoryEntries } =
+    context;
 
   const [openModal, setOpenModal] = useState<boolean>(false);
 
@@ -41,12 +35,6 @@ export function ProfilePage() {
       } else {
         updatedHistoryEntries[date] = filteredFights;
       }
-
-      if (date !== currentDate) {
-        continue;
-      }
-
-      setCurrentDayFights(updatedHistoryEntries[date]);
     }
 
     setHistoryEntries(updatedHistoryEntries);


### PR DESCRIPTION
What I changed is:

1. Removing the `currentDayFights` state and the related logic, to use just in `App.tsx` a new local state called `currentRivalFights`, that reads the `historyEntries[currentDate]` value within an `useEffect`
2. Moved all the other logic / states that are only used in `App.tsx`, from context to the specific component
3. Added a new component `SelectCurrentRival` that has some basic styles and works for getting the selected rival ID, and dynamically render the rival nickname, image, related fights, victory and defeat counters.